### PR TITLE
Refresh current project portfolio

### DIFF
--- a/src/data/lifeApi.tsx
+++ b/src/data/lifeApi.tsx
@@ -7,6 +7,8 @@ import Minimal from '../images/logos/minimal.svg';
 import { LinkedInIcon } from '../components/icons/LinkedInIcon';
 import LHVLogo from '../images/logos/uk-thumb-3.png';
 import PentaLogo from '../images/logos/penta.jpg';
+import PredictMarketsLogo from '../images/logos/predictmarkets.svg';
+import TransferTriviaLogo from '../images/logos/transfer-trivia.svg';
 
 export const Name = 'Meharpal Basi';
 
@@ -31,9 +33,32 @@ export type Project = {
 
 export const MyCurrentProjects: Project[] = [
   {
+    title: 'Transfer Trivia',
+    techStack: ['iOS App', 'React Native', 'Expo', 'Supabase'],
+    description:
+      'A Premier League daily game for guessing player transfers, built as a polished mobile app with thousands of transfer records.',
+    logo: TransferTriviaLogo,
+    link: {
+      label: 'github.com',
+      href: 'https://github.com/meharpalbasi/transfer_App',
+    },
+  },
+  {
+    title: 'Predict Markets',
+    techStack: ['Side Project', 'Next.js', 'FastAPI', 'SQLite'],
+    description:
+      'A football prediction-market intelligence app tracking Polymarket and Kalshi prices, market consensus, movement, arbitrage, and match-level signals.',
+    logo: PredictMarketsLogo,
+    link: {
+      label: 'predictmarkets.io',
+      href: 'https://predictmarkets.io',
+    },
+  },
+  {
     title: 'UK Data Jobs',
     techStack: ['Side Project', 'Next.js', 'TypeScript'],
-    description: 'A Job Board for Data Jobs in the UK',
+    description:
+      'A UK job board focused on data analyst, analytics engineer, data engineer, and data science roles.',
     logo: EvercastLogo,
     link: {
       label: 'ukdatajobs.com',
@@ -52,8 +77,9 @@ export const MyCurrentProjects: Project[] = [
   },
   {
     title: 'FPL Analyzer',
-    techStack: ['Side Project', 'Next.js'],
-    description: 'An app that allows users to bet on the outcome of the Premier League',
+    techStack: ['Side Project', 'Next.js', 'dbt', 'FastAPI'],
+    description:
+      'An FPL analytics app powered by a dbt pipeline, with player trends, expected stats, value picks, and team-strength views.',
     logo: EvercastLogo,
     link: {
       label: 'fplanaly.st',

--- a/src/images/logos/predictmarkets.svg
+++ b/src/images/logos/predictmarkets.svg
@@ -1,0 +1,7 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="64" height="64" rx="16" fill="#111827"/>
+  <path d="M14 42L25 31L33 36L49 18" stroke="#38BDF8" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="25" cy="31" r="4" fill="#F59E0B"/>
+  <circle cx="33" cy="36" r="4" fill="#22C55E"/>
+  <circle cx="49" cy="18" r="4" fill="#38BDF8"/>
+</svg>

--- a/src/images/logos/transfer-trivia.svg
+++ b/src/images/logos/transfer-trivia.svg
@@ -1,0 +1,7 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="64" height="64" rx="16" fill="#0F172A"/>
+  <path d="M18 23H42C45.3137 23 48 25.6863 48 29V41C48 44.3137 45.3137 47 42 47H24C20.6863 47 18 44.3137 18 41V23Z" fill="#16A34A"/>
+  <path d="M18 23H40C43.3137 23 46 20.3137 46 17V16H24C20.6863 16 18 18.6863 18 22V23Z" fill="#22C55E"/>
+  <path d="M27 31H39" stroke="white" stroke-width="4" stroke-linecap="round"/>
+  <path d="M33 25L39 31L33 37" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
## Summary
- adds Transfer Trivia and Predict Markets to the current projects list
- refreshes stale UK Data Jobs and FPL Analyzer descriptions
- adds small local logo assets for the new project cards

## Verification
- corepack yarn lint
- corepack yarn typecheck
- corepack yarn build compiles, then fails collecting Notion-backed note pages because the local Notion API token is invalid